### PR TITLE
Add a very basic testing notebook with aux files

### DIFF
--- a/04 - simple testing.ipynb
+++ b/04 - simple testing.ipynb
@@ -1,0 +1,192 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Testing with pytest\n",
+        "\n",
+        "If we have write a library that allows users to use different array implementations, we also need to write tests to for these.\n",
+        "\n",
+        "In this excercise we have prepared a minimal setup to use with `pytest`.\n",
+        "\n",
+        "Since we don't normally write `pytest` tests for notebooks.  We have prepared some additional files, please initialize these by running the following cell:"
+      ],
+      "metadata": {
+        "id": "vKOfj7K906jZ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install array-api-compat array-api-strict"
+      ],
+      "metadata": {
+        "id": "v2JrBTsdDop6"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "V3ASsHp9040h"
+      },
+      "outputs": [],
+      "source": [
+        "!git clone https://github.com/betatim/sound-array-api-tutorial.git\n",
+        "!cd sound-array-api-tutorial; git checkout testing\n",
+        "!cp -r sound-array-api-tutorial/testing-example .\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### \"Project\" setup\n",
+        "\n",
+        "After this, there will be a new `testing-example` folder to work with.\n",
+        "\n",
+        "On the left side, you should see a folder icon.  Click on it, then refresh.  The folder contains two fails:\n",
+        "* `utils.py` with a parametrization helper.\n",
+        "* `test_example.py` with our initial NumPy `normalize` function and a very basic test for it.\n",
+        "\n",
+        "You can edit both files by double clicking them.\n",
+        "\n",
+        "> ⚠️ Note: Edits in files are not saved over sessions.  If you need to restart, make sure to safe your changes locally.\n",
+        "\n",
+        "Right now, the files contain the NumPy version, and test with NumPy only.  You can run pytest to see that this works:"
+      ],
+      "metadata": {
+        "id": "UZYA_txyDyOH"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pytest -v testing-example"
+      ],
+      "metadata": {
+        "id": "1qSvEBLR16aQ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Task I -- Parametrize the test\n",
+        "\n",
+        "In the `utils.py` file there is a small parametrization helper that is already imported.\n",
+        "To use it decorate the test function with it:\n",
+        "```python\n",
+        "@array_api_compatible\n",
+        "```\n",
+        "After that an `xp` and `device` argument will be passed in.\n",
+        "These are the versions that should be tested.\n",
+        "\n",
+        "Adapt the test to not use `np` anymore, but rely on `xp` instead.\n",
+        "\n",
+        "Now, we can run the test again and will see failures, because it is already parametrized over `array_api_strict` and `np.mean` fails with an array from the strict Array API."
+      ],
+      "metadata": {
+        "id": "fcYbGY70Ppc_"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pytest -v testing-example"
+      ],
+      "metadata": {
+        "id": "3gEIFB3D2Mel"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Task II -- Fix the `normalize` function (again)\n",
+        "\n",
+        "Now let's fix the `normalize` function in the same file to be array-api compatible as we did before.\n",
+        "\n",
+        "Once you apply those changes and safe them, the tests will now pass:"
+      ],
+      "metadata": {
+        "id": "DC3Inx1qSZut"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pytest -v testing-example"
+      ],
+      "metadata": {
+        "id": "lI6Vza5KEiWk"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Task III -- Expand the test suite to `cupy` and `torch`\n",
+        "\n",
+        "What we really want to test most is that our library works with `cupy` and `torch` with the cuda backend.\n",
+        "\n",
+        "Now modify the `utils.py` file to try import `cupy` and `torch` and register the backends if available.\n",
+        "\n",
+        "When you are done, you should have 5 passing tests when running on a system with a cuda enabled!"
+      ],
+      "metadata": {
+        "id": "r09wqJVcS4U8"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pytest -v testing-example"
+      ],
+      "metadata": {
+        "id": "HWlSnKs3Sxpa"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### More complex testing needs\n",
+        "\n",
+        "This excercise was to show that we can parametrize tests to run with all Array API libraries we wish to support.\n",
+        "\n",
+        "In practice, many tests are more complex than this example and may use random inputs or functions like `np.testing.assert_array_almost_equal`.\n",
+        "At this time, the Array API has no helpers for testing.\n",
+        "\n",
+        "This means for more complex testing needs, you will have to define your own helpers to convert from/to NumPy or custom assertion functions that support multiple libraries.\n",
+        "Fortunately, it is only necessary to define them once for your own test suite.\n",
+        "\n",
+        "For inspiration for this, we suggest looking at the scikit-learn or SciPy tests."
+      ],
+      "metadata": {
+        "id": "Nf8IAOGvTecD"
+      }
+    }
+  ]
+}

--- a/testing-example/test_example.py
+++ b/testing-example/test_example.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from utils import array_api_compatible
+
+
+def normalize(arr):
+    mean = np.mean(arr)
+    std = np.std(arr)
+    normalized_arr = (arr - mean) / std
+
+    return normalized_arr
+
+
+def test_normalize():
+    arr = np.array([1., 2., 3., 4., 5., 6.], dtype=np.float32)
+    res = normalize(arr)
+
+    assert abs(np.mean(res)) < 1e-16
+    assert abs(np.std(res) - 1) < 1e16

--- a/testing-example/utils.py
+++ b/testing-example/utils.py
@@ -1,0 +1,39 @@
+import array_api_compat
+import array_api_strict
+import numpy as np
+import pytest
+
+
+# We store all available backends for testing.  This could be build as here
+# or be configured e.g. via environment variables.
+# scipy and scikit-learn both have similar but different setups.
+available_backends = {
+    "numpy": (np, "cpu"),
+    "strict": (array_api_strict, None),
+}
+
+# Excercise Part III
+#
+# `available_backends` is a dictionary with a namespace (this can be cupy,
+# or torch) that is used to get the available Array API backends below and
+# define the correct `xp` and `device`.
+#
+# We wish to extend this in our tests to:
+#
+# * cupy, device can be `None`
+# * torch[cpu]
+# * torch[cuda]
+#
+# When the import succeeds (and cuda is available)
+
+
+def get_available_backends():
+    for key, (array_mod, device) in available_backends.items():
+        # The module is the original module, use array_api_compat to fetch
+        # the compatible namespace:
+        xp = array_api_compat.get_namespace(array_mod.asarray(1))
+        yield pytest.param(xp, device, id=key)
+
+array_api_compatible = pytest.mark.parametrize(
+    "xp, device", get_available_backends()
+)


### PR DESCRIPTION
This is a very basic testing example.  I already added the parametrization, because I thought it might be tricky enough to understand what a parametrization even does...

So currently, the exercise is:
1. Parametrize the existing (trivial) test to use `xp` rather than `np`.
2. Fix the `normalize` function (again), which should be simple enough.
3. Expand the `available_backends` to include cupy, torch cpu, and torch cuda.

Since one is bound to run into annoying errors (e.g. device has to be `None`, forget to replace an `xp`), I suppose this might be about as much as one can do?

Anyway, the take away would hopefully be:  You can have one test for multiple implementations, even if you may have to end up adding quite a few helpers.